### PR TITLE
Fixed error: adjusted coefficients names (b_varam and b_explX)

### DIFF
--- a/regression/LTStsVarSel.m
+++ b/regression/LTStsVarSel.m
@@ -464,7 +464,7 @@ while AllPvalSig == 0
         LastTrendPval=0;
     end
     
-    posX=seqp(contains(rownam,'b_X'));
+    posX=seqp(contains(rownam,'b_explX'));
     if ~isempty(posX)
         % if iniloop is 0 the pval of the last expl variable is in reality
         % the pval of the level shift component and therefore it has to be
@@ -488,7 +488,7 @@ while AllPvalSig == 0
     end
     
     % tre=cellfun(@isempty,strfind(rownam,'b_varamp'));
-    posLastVarAmpl=max(seqp(contains(rownam,'b_varamp')));
+    posLastVarAmpl=max(seqp(contains(rownam,'b_varam')));
     
     if ~isempty(posLastVarAmpl)
         LastVarAmplPval=out_LTSts.Btable{posLastVarAmpl,'pval'};


### PR DESCRIPTION
## Proposed changes

The names of the rows of the coefficients table were not coherent with the output of LTSts.

## Types of changes

What types of changes does your code introduce to FSDA?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


