### PR TITLE
Updated the upload-artifact.yml to align with File Exchange

### DIFF
--- a/.github/workflows/upload-artifact.yml
+++ b/.github/workflows/upload-artifact.yml
@@ -116,7 +116,7 @@ jobs:
           files: ./toolbox/bin/FSDA.mltbx
           fail_on_unmatched_files: true
           generate_release_notes: true
-          draft: true
+          draft: false
       
   build-docker-container:
     needs: archive-build-artifacts

--- a/.github/workflows/upload-artifact.yml
+++ b/.github/workflows/upload-artifact.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Define a specific version of MATLAB to release the toolbox
-  MATLAB_RELEASE: R2023a
+  MATLAB_RELEASE: R2024a
   # We also need a specific version to build the older v3 doc search
   MATLAB_RELEASE_DOC_V3: R2021b
   


### PR DESCRIPTION
I have modified the upload-artifact.yml to align with File Exchange, this modification should fix the toolbox from getting unlisted from File Exchange whenever a new release is made.

The original workflow created a release and then attached the MLTBX to the release. In the current workflow, creating a release and uploading the MLTBX are done in a single step.

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY."
