### PR TITLE
Add 'boll' option to choices in function signatures

### DIFF
--- a/toolbox/utilities/functionSignatures.json
+++ b/toolbox/utilities/functionSignatures.json
@@ -184,7 +184,7 @@
             "scalar",
             "field Name required",
             "Name choices={'candle','line','ma','boll'}",
-            "admissible fields depend on Name: candle->{Name,widthFactor,upColor,downColor}; line->{Name}; ma->{Name,maFastLen,maMidLen,maSlowLen,showMACrossovers}"
+            "admissible fields depend on Name: candle->{Name,widthFactor,upColor,downColor}; line->{Name}; ma->{Name,maFastLen,maMidLen,maSlowLen,showMACrossovers}; boll->{Name,bollWindow,bollNumStd}"
           ]
         ],
         "purpose": "Type of plot in the top panel; \n when supplied as a struct, \n it also controls the suboptions associated with the selected visualization"

--- a/toolbox/utilities/functionSignatures.json
+++ b/toolbox/utilities/functionSignatures.json
@@ -173,17 +173,17 @@
         "type": [
           [
             "char",
-            "choices={'candle','line','ma'}"
+            "choices={'candle','line','ma','boll'}"
           ],
           [
             "string",
-            "choices={'candle','line','ma'}"
+            "choices={'candle','line','ma','boll'}"
           ],
           [
             "struct",
             "scalar",
             "field Name required",
-            "Name choices={'candle','line','ma'}",
+            "Name choices={'candle','line','ma','boll'}",
             "admissible fields depend on Name: candle->{Name,widthFactor,upColor,downColor}; line->{Name}; ma->{Name,maFastLen,maMidLen,maSlowLen,showMACrossovers}"
           ]
         ],


### PR DESCRIPTION
## Proposed changes

### Summary
This PR adds the missing `'boll'` (Bollinger Bands) option to the auto-completion choices in `functionSignatures.json`.

### Description of changes
- Added `'boll'` to the valid character/string choices for the `topPanelMode` parameter.
- Added `'boll'` to the valid `Name` choices when the parameter is passed as a struct.
- (Opzionale, se fai la modifica che ti ho suggerito) Updated the documentation string to include `bollWindow` and `bollNumStd` as admissible fields for the Bollinger struct.

### Motivation
To improve the user experience and ensure that the Bollinger Bands technical indicator is properly suggested by MATLAB's auto-complete feature when using the `getYahoo` function.

